### PR TITLE
making public schema explicit

### DIFF
--- a/reopt_api/dev_settings.py
+++ b/reopt_api/dev_settings.py
@@ -116,6 +116,9 @@ elif 'test' in sys.argv or os.environ.get('APP_ENV') == 'local':
             'NAME': 'reopt',
             'USER': 'reopt',
             'PASSWORD': 'reopt',
+            'OPTIONS': {
+                 'options': '-c search_path=public'
+             },
             'HOST': 'localhost',
             'PORT': '',
         }


### PR DESCRIPTION
This makes the use of public schema explicit for local environment use. Necessary on some builds (i.e. Docker)