### PR TITLE
added julia environment activation

### DIFF
--- a/reo/src/run_jump_model.py
+++ b/reo/src/run_jump_model.py
@@ -55,6 +55,8 @@ def run_jump_model(self, dfm, data, run_uuid, bau=False):
     logger.info("Running JuMP model ...")
     try:
         j = julia.Julia()
+        j.using("Pkg")
+        j.eval('Pkg.activate("./")')
         j.include("reo/src/reopt.jl")
         results = j.reopt(data, reopt_inputs)
     except Exception as e:


### PR DESCRIPTION
I found that after I had a clean install of julia without all of the packages that we use in this repo, we didn't put an automated activation of the julia environment. This fix isn't great for multiple runs (like running the test) so let me know if you think we should do something else.