### PR TITLE
Point to REopt.jl master branch

### DIFF
--- a/.github/workflows/pull_request_tests.yml
+++ b/.github/workflows/pull_request_tests.yml
@@ -26,6 +26,8 @@ jobs:
         env:
           NREL_DEV_API_KEY: ${{ secrets.NREL_DEV_API_KEY }}
         run: ./.github/scripts/make_keys.py.sh 
+      - name: Remove existing base-api-image
+        run: docker rmi docker.io/library/base-api-image:latest || true
       - name: Build containers
         run: docker compose up -d
       - name: Check running containers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Classify the change according to the following categories:
     ##### Removed
     ### Patches
 
+## juliamaster
+### Minor Updates
+##### Changed
+- point to the master branch of REopt.jl instead of the latest registered version (temporary solution while resolving Julia Registry issues caused by REopt.jl repo url name change due to lab renaming)
+
 ## v3.17.5
 ### Minor Updates
 ##### Added

--- a/julia_src/Manifest.toml
+++ b/julia_src/Manifest.toml
@@ -948,9 +948,11 @@ version = "1.11.0"
 
 [[deps.REopt]]
 deps = ["ArchGDAL", "CSV", "CoolProp", "DataFrames", "Dates", "DelimitedFiles", "HTTP", "JLD", "JSON", "JuMP", "LinDistFlow", "LinearAlgebra", "Logging", "MathOptInterface", "Requires", "Roots", "Statistics", "TestEnv"]
-git-tree-sha1 = "00bb39c8f932a3320960f01adc139229c24e12b7"
+git-tree-sha1 = "91b47616ee38c784c5f454e1ad4ead1b119e818f"
+repo-rev = "master"
+repo-url = "https://github.com/NREL/REopt.jl.git"
 uuid = "d36ad4e8-d74a-4f7a-ace1-eaea049febf6"
-version = "0.56.2"
+version = "0.57.0"
 
 [[deps.Random]]
 deps = ["SHA"]

--- a/julia_src/utils.jl
+++ b/julia_src/utils.jl
@@ -19,7 +19,7 @@ function filter_dict_to_match_struct_field_names(d::Dict, s::DataType)
         end
     end
     return d2
-end
+end 
 
 """
     array_of_array_to_2D_array(aa)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] CHANGELOG.md is updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Any new Django model inputs have also been added to job/test/posts/all_inputs_test.json

### What kind of change does this PR introduce?
bug fixes and defaults update

### What is the current behavior?
- Boiler emissions not in emissions calculations
- Out of date federal defaults for **Financial** inputs
- "HIMS" region incorrectly named "HI" in AVERT data

### What is the new behavior (if this is a feature change)?
### Fixed
- Include boiler emissions in emissions calculations
- Handle "HIMS" region incorrectly named "HI" in AVERT data
### Changed
- Updated defaults for **Financial** inputs **elec_cost_escalation_rate_fraction**, **boiler_fuel_cost_escalation_rate_fraction**, **existing_boiler_fuel_cost_escalation_rate_fraction**, **chp_fuel_cost_escalation_rate_fraction**, **generator_fuel_cost_escalation_rate_fraction**, **om_cost_escalation_rate_fraction**, and **offtaker_discount_rate_fraction** when **sector** is "federal" (based on the 2025 NIST Handbook and Annual Supplement)

### Does this PR introduce a breaking change?
Federal **Financial** default changes. Specify inputs to keep results unchanged.

### Other information:
