### PR TITLE
Reenable production deploys after dry-run tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,9 +114,6 @@ jobs:
       metadata: ${{ needs.deploy-metadata.outputs.production-metadata }}
       vault-registry-credentials-path: secret/data/deploy/common/aws-ecr
       vault-kubeconfig-path: secret/data/deploy/production/on-prem-rancher-ponderosa-cluster-reopt
-      # FIXME: Temporarily disable deploys and perform a dry run so we can see
-      # how all this would get rolled out once we merge with `main`.
-      dry-run: true
     secrets:
       vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
       vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
Part of the larger, manual rollout of the deployment changes in https://github.com/NatLabRockies/REopt_API/pull/714