### PR TITLE
Remove nrel.gov ingress

### DIFF
--- a/config/deploy/WebDeployment.pkl
+++ b/config/deploy/WebDeployment.pkl
@@ -366,34 +366,6 @@ resources: Listing<K8sResource> = new {
   new TadaWebIngress {
     tadaName = "django"
     tadaServicePort = 8000
-
-    // Configure the ingress to listen on the old `*.nrel.gov` domains (in
-    // addition to the new `nlr.gov` domains). We can remove this once the
-    // nrel.gov domain is fully gone.
-    local nrelHost = deployMetadata.`url-host`.replaceLast(".nlr.gov", ".nrel.gov")
-    spec {
-      rules {
-        new {
-          host = nrelHost!!
-          http {
-            paths {
-              new {
-                path = "/"
-                pathType = "Prefix"
-                backend {
-                  service {
-                    name = djangoService.metadata.name
-                    port {
-                      number = 8000
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
   }
 
   new TadaWebPodDisruptionBudget {}


### PR DESCRIPTION
Remove the duplicative nrel.gov ingress now that everything with developer.nlr.gov is cutover to use the nlr.gov ingress.